### PR TITLE
Revert "Bump flox-lib from 0.18.0 to 0.18.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flox-lib==0.18.1
+flox-lib==0.18.0
 PyGithub==1.55
 requests==2.25.1


### PR DESCRIPTION
Reverts Garulf/Github-Notifications#14