### PR TITLE
Prefer packaged modules over system wide

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Github Notifications",
   "Description": "View your github notifications",
   "Author": "Garulf",
-  "Version": "3.0.8",
+  "Version": "3.1.0",
   "Language": "python",
   "Website": "https://github.com/Garulf/github-notifications",
   "IcoPath": "./icon.png",

--- a/run.py
+++ b/run.py
@@ -2,9 +2,9 @@ import sys
 import os
 
 plugindir = os.path.abspath(os.path.dirname(__file__))
-sys.path.append(plugindir)
-sys.path.append(os.path.join(plugindir, "lib"))
-sys.path.append(os.path.join(plugindir, "plugin"))
+sys.path.insert(0, plugindir)
+sys.path.insert(0, os.path.join(plugindir, "lib"))
+sys.path.insert(0, os.path.join(plugindir, "plugin"))
 
 from plugin.main import GithubNotifications
 


### PR DESCRIPTION
THis adds the plugin's lib path to the top of sys path. This would fix any issues with a users system installed packages.